### PR TITLE
Demonstrate problem with NTA types in my test scaffold.

### DIFF
--- a/src/nupic/utils/Random.cpp
+++ b/src/nupic/utils/Random.cpp
@@ -126,7 +126,7 @@ Random::~Random()
 }
 
 
-Random::Random(unsigned long seed)
+Random::Random(UInt64 seed)
 {
   seed_ = seed;
 

--- a/src/nupic/utils/Random.hpp
+++ b/src/nupic/utils/Random.hpp
@@ -82,7 +82,7 @@ namespace nupic {
   {
   public:
 
-    Random(unsigned long seed = 0);
+    Random(UInt64 seed = 0);
 
     // support copy constructor and operator= -- these require non-default
     // implementations because of the impl_ pointer.


### PR DESCRIPTION
`export NUPIC_CORE=$(cd ~/nta/capnpfix-prototype pwd)`
Configure with `cmake $NUPIC_CORE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../release -DPY_EXTENSIONS_DIR=$NUPIC_CORE/bindings/py/nupic/bindings`
Then build `make install`.

Then run test:
```
~/nta/capnpfix-prototype/bindings/py/tests (nta-types-problem)$ python nupic_random_test.py
E
======================================================================
ERROR: testConstructor (__main__.TestNupicRandom)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "nupic_random_test.py", line 35, in testConstructor
    r = Random(42)
  File "/Users/vkruglikov/Library/Python/2.7/lib/python/site-packages/nupic/bindings/math.py", line 161, in __init__
    this = _math.new_Random(*args)
NotImplementedError: Wrong number or type of arguments for overloaded function 'new_Random'.
  Possible C/C++ prototypes are:
    nupic::Random::Random(UInt64)
    nupic::Random::Random(nupic::Random const &)
```